### PR TITLE
Switch back-ticks to to single quotes 

### DIFF
--- a/step.sh
+++ b/step.sh
@@ -111,7 +111,7 @@ if [ ! -z "${dsym_path}" ] ; then
 	fi
 
 	if [ -z "${api_key}" ] && [ -z "${service_info_plist_path}" ] ; then
-		echo_fail "Either `Fabric: API Key` (api_key) or `GoogleService-Info.plist path` (service_info_plist_path) needs to specified for dSYM upload."
+		echo_fail "Either 'Fabric: API Key' (api_key) or 'GoogleService-Info.plist path' (service_info_plist_path) needs to specified for dSYM upload."
 	fi
 
 	if [ ! -z "${service_info_plist_path}" ] && [ ! -f "${service_info_plist_path}" ] ; then 
@@ -168,7 +168,7 @@ if [ ! -z "${dsym_path}" ] ; then
   dsym_cmd="${THIS_SCRIPT_DIR}/Fabric/upload-symbols"
 
   if [ ! -z "${service_info_plist_path}" ] ; then
-	echo_info "`GoogleService-Info.plist path` (service_info_plist_path) provided, using it instead of `Fabric: API Key` (api_key)"
+	echo_info "'GoogleService-Info.plist path' (service_info_plist_path) provided, using it instead of 'Fabric: API Key' (api_key)"
 	dsym_cmd="${dsym_cmd} -gsp \"${service_info_plist_path}\""
   else
   	dsym_cmd="${dsym_cmd} -a \"${api_key}\""


### PR DESCRIPTION
switch back-ticks to use single quotes to  avoid attempted execution of strings, fix for issue #32 